### PR TITLE
Correct error that caused it to not recognize developer mode

### DIFF
--- a/src/Plugin/FileValidator.php
+++ b/src/Plugin/FileValidator.php
@@ -14,7 +14,7 @@ use Magento\Framework\{
 
 class FileValidator
 {
-    const MODE_DEVELOPMENT = 'development';
+    const MODE_DEVELOPMENT = 'developer';
     private $reader;
 
     public function __construct(\Magento\Framework\App\DeploymentConfig\Reader $reader)


### PR DESCRIPTION
This module wasn't working for me because it was checking for `development` mode instead of `developer`.